### PR TITLE
Replaced hard coded year with dynamic value

### DIFF
--- a/src/js/components/footer.jsx
+++ b/src/js/components/footer.jsx
@@ -13,7 +13,8 @@ const Footer = () => (
 			/>
 		</nav>
 		<small className="copyright">
-			© 2018–2021 Zotero &nbsp;•&nbsp; <a href="/faq#privacy">Privacy</a>
+			© 2018–{new Date().getFullYear()} Zotero &nbsp;•&nbsp;{" "}
+			<a href="/faq#privacy">Privacy</a>
 		</small>
 	</footer>
 );


### PR DESCRIPTION
Replacing the fixed year of the copyright notice in the footer with a dynamic value so it does not need to be touched every year.
See #254 